### PR TITLE
Potential fix for code scanning alert no. 2: Expression injection in Actions

### DIFF
--- a/.github/workflows/discord-pr-notify.yml
+++ b/.github/workflows/discord-pr-notify.yml
@@ -11,11 +11,15 @@ jobs:
     if: github.head_ref != 'changeset-release/main'
     steps:
       - name: Send Discord Notification
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           PAYLOAD=$(jq -n \
-            --arg title "${{ github.event.pull_request.title }}" \
-            --arg url "${{ github.event.pull_request.html_url }}" \
-            --arg author "${{ github.event.pull_request.user.login }}" \
+            --arg title "$PR_TITLE" \
+            --arg url "$PR_URL" \
+            --arg author "$PR_AUTHOR" \
             '{
               content: ("🚀 **New PR:** " + $title + "\n🔗 <" + $url + ">\n👤 **Author:** " + $author),
               thread_name: ($title + " by " + $author)


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/Roo-Code/security/code-scanning/2](https://github.com/MjrTom/Roo-Code/security/code-scanning/2)

To fix the problem, we need to avoid directly using user-controlled inputs in the `jq` command. Instead, we should set these inputs to intermediate environment variables and then use the shell syntax to read these environment variables within the `jq` command. This approach will prevent any potential command injection.

1. Set the user-controlled inputs (`title`, `url`, `author`) to intermediate environment variables.
2. Use the shell syntax to read these environment variables within the `jq` command.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
