### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -74,7 +74,14 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 		const isAzureAiInference = this._isAzureAiInference(modelUrl)
 		const urlHost = this._getUrlHost(modelUrl)
 		const deepseekReasoner = modelId.includes("deepseek-reasoner") || enabledR1Format
-		const ark = modelUrl.includes(".volces.com")
+		let ark = false
+		try {
+			const parsedUrl = new URL(modelUrl)
+			const host = parsedUrl.host
+			ark = host === "volces.com" || host.endsWith(".volces.com")
+		} catch (error) {
+			// Invalid URL, ark remains false
+		}
 
 		if (modelId.startsWith("o3-mini")) {
 			yield* this.handleO3FamilyMessage(modelId, systemPrompt, messages)


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/Roo-Code/security/code-scanning/3](https://github.com/MjrTom/Roo-Code/security/code-scanning/3)

To fix the issue, we need to replace the substring check `modelUrl.includes(".volces.com")` with a proper validation of the host component of the URL. This can be achieved by parsing the URL using the `URL` class, extracting the `host`, and checking if it matches the allowed domain or its subdomains. Specifically, we should ensure that the host ends with `.volces.com` and is not preceded by any additional characters (e.g., `evil.volces.com` should not match).

Steps to implement the fix:
1. Parse the `modelUrl` using the `URL` class.
2. Extract the `host` component of the URL.
3. Check if the `host` ends with `.volces.com` and is either exactly `.volces.com` or a subdomain of it.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
